### PR TITLE
chore: bump go.mod to 1.26.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/depgraph
 
-go 1.25
+go 1.26.0
 
 require (
 	github.com/luno/jettison v0.0.0-20260328151427-502b299c2358


### PR DESCRIPTION
Bump the `go` directive in `go.mod` to `1.26.0`.